### PR TITLE
FDT generation issues under 64bit Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ CONFIG_LOCALVERSION =
 CPPFLAGS = -I libfdt
 WARNINGS = -Wall -Wpointer-arith -Wcast-qual -Wnested-externs \
 	-Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls
-CFLAGS = -g -Os -fPIC $(WARNINGS) -m32
+CFLAGS   = -g -Os -fPIC $(WARNINGS) -m32
+LDFLAGS  = -m32
 
 BISON = bison
 LEX = flex

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CONFIG_LOCALVERSION =
 CPPFLAGS = -I libfdt
 WARNINGS = -Wall -Wpointer-arith -Wcast-qual -Wnested-externs \
 	-Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls
-CFLAGS = -g -Os -fPIC $(WARNINGS)
+CFLAGS = -g -Os -fPIC $(WARNINGS) -m32
 
 BISON = bison
 LEX = flex


### PR DESCRIPTION
While working on a board port, I was struggling with failures in the devicetree preparation stage of GenericBooter. I traced the problem to improper dtb output from dtc due to some (suspected) cross-arch incompatibilities in the source. I resolved the issue by reverting the previous fix and adding linker flags to support building dtc as a 32 bit binary. (Now on to pexpert! ;)
